### PR TITLE
remove aspect ratio constraint from signature modifier

### DIFF
--- a/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
+++ b/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
@@ -95,7 +95,7 @@ public fun Sain(
                     bitmap = it,
                     contentDescription = "Signature",
                     modifier = Modifier
-                        .fillMaxSize()
+                        .fillMaxSize(),
                 )
             }
         }

--- a/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
+++ b/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -97,7 +96,6 @@ public fun Sain(
                     contentDescription = "Signature",
                     modifier = Modifier
                         .fillMaxSize()
-                        .aspectRatio(1f),
                 )
             }
         }


### PR DESCRIPTION
This pull request to `sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt` includes changes to streamline the layout by removing the aspect ratio constraint from the `Image` component.

Layout adjustments:

* [`sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt`](diffhunk://#diff-580bbe4bd1e8ca179a4d23e16f77a780e832fe58b6f91d6e9663a6abd0c0e0d3L22): Removed the import for `aspectRatio` as it is no longer used.
* [`sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt`](diffhunk://#diff-580bbe4bd1e8ca179a4d23e16f77a780e832fe58b6f91d6e9663a6abd0c0e0d3L100): Removed the `aspectRatio(1f)` modifier from the `Image` component to allow it to fill the maximum size without maintaining a fixed aspect ratio.
* This closes #72 