### PR TITLE
feat: enhance signature component with customizable parameters e.g signatureHeight, signaturePadColor, signaturePadBorderColor, signaturePadBorderThickness, and signaturePadShape

### DIFF
--- a/sain/api/android/sain.api
+++ b/sain/api/android/sain.api
@@ -1,6 +1,10 @@
 public final class io/github/joelkanyi/sain/SainKt {
-	public static final fun Sain-uKGX-YA (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFLio/github/joelkanyi/sain/SignatureState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Sain-cxYskoo (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFFJJFLandroidx/compose/foundation/shape/CornerBasedShape;Lio/github/joelkanyi/sain/SignatureState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public static final fun rememberSignatureState (Landroidx/compose/runtime/Composer;I)Lio/github/joelkanyi/sain/SignatureState;
+}
+
+public final class io/github/joelkanyi/sain/SainUtils_androidKt {
+	public static final fun toBase64 (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/lang/String;
 }
 
 public final class io/github/joelkanyi/sain/SignatureAction : java/lang/Enum {

--- a/sain/api/jvm/sain.api
+++ b/sain/api/jvm/sain.api
@@ -1,6 +1,10 @@
 public final class io/github/joelkanyi/sain/SainKt {
-	public static final fun Sain-uKGX-YA (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFLio/github/joelkanyi/sain/SignatureState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Sain-cxYskoo (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFFJJFLandroidx/compose/foundation/shape/CornerBasedShape;Lio/github/joelkanyi/sain/SignatureState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public static final fun rememberSignatureState (Landroidx/compose/runtime/Composer;I)Lio/github/joelkanyi/sain/SignatureState;
+}
+
+public final class io/github/joelkanyi/sain/SainUtils_jvmKt {
+	public static final fun toBase64 (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/lang/String;
 }
 
 public final class io/github/joelkanyi/sain/SignatureAction : java/lang/Enum {

--- a/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
+++ b/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
@@ -16,10 +16,16 @@
 package io.github.joelkanyi.sain
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
@@ -50,21 +56,36 @@ import androidx.compose.ui.unit.dp
  *    performed on the signature. We only have two actions:
  *    [SignatureAction.CLEAR] and [SignatureAction.COMPLETE].
  */
-@Suppress("ktlint:compose:modifier-not-used-at-root")
 @Composable
 public fun Sain(
     onComplete: (signature: ImageBitmap?) -> Unit,
     modifier: Modifier = Modifier,
     signatureColor: Color = Color.Black,
     signatureThickness: Dp = 5.dp,
+    signatureHeight: Dp = 250.dp,
+    signaturePadColor: Color = Color.White,
+    signaturePadBorderColor: Color = Color.Black,
+    signaturePadBorderThickness: Dp = .5.dp,
+    signaturePadShape: CornerBasedShape = RoundedCornerShape(8.dp),
     state: SignatureState = rememberSignatureState(),
     actions: @Composable (
         action: (SignatureAction) -> Unit,
     ) -> Unit,
 ) {
-    Column {
+    Column(
+        modifier = modifier
+            .fillMaxWidth(),
+    ) {
         Box(
-            modifier = modifier
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(signatureHeight)
+                .background(signaturePadColor)
+                .border(
+                    color = signaturePadBorderColor,
+                    width = signaturePadBorderThickness,
+                    shape = signaturePadShape,
+                )
                 .pointerInput(true) {
                     detectDragGestures { change, dragAmount ->
                         change.consume()

--- a/sample/shared/src/commonMain/kotlin/com.composesignature.sample/Sample.kt
+++ b/sample/shared/src/commonMain/kotlin/com.composesignature.sample/Sample.kt
@@ -15,9 +15,7 @@
  */
 package com.composesignature.sample
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
@@ -73,16 +71,10 @@ fun Sample(
             )
 
             Sain(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(250.dp)
-                    .border(
-                        BorderStroke(
-                            width = .5.dp,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        ),
-                        shape = RoundedCornerShape(8.dp),
-                    ),
+                signatureHeight = 250.dp,
+                signaturePadBorderColor = MaterialTheme.colorScheme.onSurface,
+                signaturePadBorderThickness = .5.dp,
+                signaturePadShape = RoundedCornerShape(8.dp),
                 onComplete = { signatureBitmap ->
                     if (signatureBitmap != null) {
                         imageBitmap = signatureBitmap


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `Sain` library, including changes to the API, new utility functions, and improvements to the `Sain` composable function. The most important changes are summarized below:

### API Changes:
* Updated the `Sain` function signature in `sain/api/android/sain.api` and `sain/api/jvm/sain.api` to include new parameters for customizing the signature pad. [[1]](diffhunk://#diff-e4c50ee0f8205a43df287a24c5607c527b0f560a7f3304f2474473ab4d9761a8L2-R9) [[2]](diffhunk://#diff-a1ec7f6f156a4d6ab1a0b2fdbcbd644dc309c693642859af87bbfda298ed2d29L2-R9)

### Enhancements to `Sain` Composable:
* Added new parameters to the `Sain` composable function in `sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt` for customizing the appearance of the signature pad, including `signatureHeight`, `signaturePadColor`, `signaturePadBorderColor`, `signaturePadBorderThickness`, and `signaturePadShape`.
* Included additional imports in `sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt` to support the new customization options.

### Sample App Adjustments:
* Updated the `Sample` composable function in `sample/shared/src/commonMain/kotlin/com.composesignature.sample/Sample.kt` to use the new `Sain` composable parameters for customizing the signature pad.