### PR TITLE
feat: automate version bumping in gradle.properties during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,35 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      - name: Extract version from tag
+        run: |
+          VERSION_NAME="${GITHUB_REF#refs/tags/}"  # Remove "refs/tags/"
+          echo "Extracted VERSION_NAME: $VERSION_NAME"  # Debugging step
+          echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+
+      - name: Update version in gradle.properties
+        run: |
+          sed -i "s/^version=.*/version=${{ env.VERSION_NAME }}/" gradle.properties
+
+      - name: Commit and push version change to main branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main
+          git checkout main
+          git pull origin main
+
+          git add gradle.properties
+          git commit -m "Bump version to ${{ env.VERSION_NAME }}" || echo "No changes to commit"
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
       - name: Make gradle executable
         run: chmod +x ./gradlew
+
+      - uses: gradle/gradle-build-action@v3
 
       - uses: gradle/gradle-build-action@v3
       - name: Deploy to Maven Central

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
-# Lib version
-version=2.0.7
-
 #Gradle
 org.gradle.jvmargs=-Xmx4048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4048M"
 org.gradle.caching=true
@@ -29,3 +26,6 @@ org.jetbrains.compose.experimental.wasm.enabled=true
 
 #macOS
 org.jetbrains.compose.experimental.macos.enabled=true
+
+# Lib version
+version=2.0.7


### PR DESCRIPTION
This pull request includes changes to automate the versioning process in the Gradle build workflow and update the `gradle.properties` file accordingly.

Automation of versioning in Gradle build workflow:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R43-R72): Added steps to extract the version from the tag, update the version in `gradle.properties`, and commit and push the changes to the main branch.

Updates to `gradle.properties`:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-L3): Moved the version declaration to a different location within the file. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-L3) [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R29-R31)