### PR TITLE
fix: introduces a custom Saver that correctly saves and restores the state of the signature.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="sample.android">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="SignatureStateSaverTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/sain/build.gradle.kts
+++ b/sain/build.gradle.kts
@@ -16,7 +16,9 @@
 
 @file:Suppress("DEPRECATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -39,6 +41,14 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_1_8)
         }
         publishLibraryVariants("release")
+
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+
+        dependencies {
+            androidTestImplementation("androidx.compose.ui:ui-test-junit4-android:1.8.2")
+            debugImplementation("androidx.compose.ui:ui-test-manifest:1.8.2")
+        }
     }
 
     jvm()
@@ -63,8 +73,17 @@ kotlin {
             implementation(compose.foundation)
         }
 
+        // Adds common test dependencies
         commonTest.dependencies {
-            implementation(libs.kotlin.test)
+            implementation(kotlin("test"))
+
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+        }
+
+        // Adds the desktop test dependency
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
         }
     }
 }
@@ -75,6 +94,7 @@ android {
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
+++ b/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
@@ -288,14 +289,25 @@ public class SignatureState {
     }
 
     public companion object {
-        public val Saver: Saver<SignatureState, *> = Saver(
-            save = {
-                it.signatureLines to it.signature
+        public val Saver: Saver<SignatureState, Any> = Saver(
+            save = { state ->
+                // Store only values that are Parcelable/Serializable
+                state.signatureLines.map { line ->
+                    listOf(line.start.x, line.start.y, line.end.x, line.end.y)
+                }
             },
-            restore = {
+            restore = { saved ->
+                @Suppress("UNCHECKED_CAST")
+                val points = saved as List<List<Float>>
                 SignatureState().apply {
-                    _signatureLines.addAll(it.first)
-                    _signature.value = it.second
+                    _signatureLines.addAll(
+                        points.map {
+                            SignatureLine(
+                                start = Offset(it[0], it[1]),
+                                end = Offset(it[2], it[3]),
+                            )
+                        },
+                    )
                 }
             },
         )


### PR DESCRIPTION
The default `Saver` for `SignatureState` does not correctly save and restore the state of the signature. This commit introduces a custom `Saver` that correctly saves and restores the state of the signature.

The custom `Saver` saves the `signatureLines` as a list of lists of floats, where each inner list represents a line and contains the x and y coordinates of the start and end points of the line. The `restore` function then reconstructs the `SignatureLine` objects from the saved list of floats.

Additionally, this commit updates the project dependencies to include the necessary libraries for testing the `Saver`.

This fixes #91 