### PR TITLE
feat: add ImageBitmap.toPngByteArray() and ImageBitmap.toBase64() helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ See the [project's website](https://joelkanyi.github.io/sain/) for full document
 ## Features
 
 - Capture signatures as `ImageBitmap` on all platforms
+- Export signatures as PNG bytes or a Base64 string with `toPngByteArray()` and `toBase64()`
 - Customizable signature color, thickness, pad color, shape, and border
 - Optional guideline with configurable style, padding, and dash pattern
 - Hint text when the signature pad is empty

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ A Compose Multiplatform library for capturing and exporting signatures as `Image
 ## Features
 
 - Capture signatures as `ImageBitmap` on all platforms
+- Export signatures as PNG bytes or a Base64 string with `toPngByteArray()` and `toBase64()`
 - Customizable signature color, thickness, pad color, shape, and border
 - Optional guideline with configurable style, padding, and dash pattern
 - Hint text when the signature pad is empty

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,65 +96,26 @@ The `SignatureAction` enum has two values:
 | `hintText` | `String` | `"Sign within this area"` | The hint text displayed when the signature pad is empty. |
 | `hintTextStyle` | `TextStyle` | Gray, 16sp, centered | The text style of the hint text. |
 
-## Base64 Encoding
+## Exporting the Signature
 
-To store or transfer an `ImageBitmap` in a platform-independent format, you can convert it to a Base64 string. Define an `expect`/`actual` function across your source sets:
+Sain ships with helpers to export the captured `ImageBitmap` in a platform-independent format on all targets (Android, iOS, JVM, JS, and WASM):
 
-### commonMain
-
-```kotlin
-expect fun ImageBitmap.toBase64(): String
-```
-
-### androidMain
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `ImageBitmap.toPngByteArray()` | `ByteArray` | The bitmap encoded as PNG bytes. |
+| `ImageBitmap.toBase64()` | `String` | The Base64 string of the PNG-encoded bitmap. |
 
 ```kotlin
-actual fun ImageBitmap.toBase64(): String {
-    val bitmap = this.asAndroidBitmap()
-    val byteArrayOutputStream = ByteArrayOutputStream()
-    bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
-    val byteArray = byteArrayOutputStream.toByteArray()
-    return Base64.encodeToString(byteArray, Base64.NO_WRAP)
-}
+Sain(
+    onComplete = { signatureBitmap ->
+        if (signatureBitmap != null) {
+            val pngBytes = signatureBitmap.toPngByteArray()
+            val base64 = signatureBitmap.toBase64()
+            // Store or transfer the bytes or the Base64 string as needed
+        }
+    },
+    ...
+)
 ```
 
-### iosMain
-
-```kotlin
-@OptIn(ExperimentalForeignApi::class)
-fun ImageBitmap.toUIImage(): UIImage? {
-    val width = this.width
-    val height = this.height
-    val buffer = IntArray(width * height)
-
-    this.readPixels(buffer)
-
-    val colorSpace = CGColorSpaceCreateDeviceRGB()
-    val context = CGBitmapContextCreate(
-        data = buffer.refTo(0),
-        width = width.toULong(),
-        height = height.toULong(),
-        bitsPerComponent = 8u,
-        bytesPerRow = (4 * width).toULong(),
-        space = colorSpace,
-        bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
-    )
-
-    val cgImage = CGBitmapContextCreateImage(context)
-    return cgImage?.let { UIImage.imageWithCGImage(it) }
-}
-
-actual fun ImageBitmap.toBase64(): String {
-    val uiImage = this.toUIImage()
-    val jpegData = uiImage?.let { UIImageJPEGRepresentation(it, 0.5) }
-        ?: return ""
-    return jpegData.base64Encoding()
-}
-```
-
-### Usage
-
-```kotlin
-val base64String = imageBitmap.toBase64()
-// Store or transfer the base64String as needed
-```
+`toBase64()` returns only the Base64 payload. To display it in an HTML `img` tag or similar, prefix it with `data:image/png;base64,`.

--- a/sain/api/android/sain.api
+++ b/sain/api/android/sain.api
@@ -1,3 +1,11 @@
+public final class io/github/joelkanyi/sain/ImageBitmapEncodingKt {
+	public static final fun toBase64 (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/lang/String;
+}
+
+public final class io/github/joelkanyi/sain/ImageBitmapEncoding_androidKt {
+	public static final fun toPngByteArray (Landroidx/compose/ui/graphics/ImageBitmap;)[B
+}
+
 public final class io/github/joelkanyi/sain/SainKt {
 	public static final fun Sain-JOs5j9Q (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFFJLandroidx/compose/foundation/BorderStroke;Landroidx/compose/foundation/shape/CornerBasedShape;Lio/github/joelkanyi/sain/SignatureState;ZJF[FFFLjava/lang/String;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Sain-uKGX-YA (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFLio/github/joelkanyi/sain/SignatureState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V

--- a/sain/api/jvm/sain.api
+++ b/sain/api/jvm/sain.api
@@ -1,3 +1,11 @@
+public final class io/github/joelkanyi/sain/ImageBitmapEncodingKt {
+	public static final fun toBase64 (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/lang/String;
+}
+
+public final class io/github/joelkanyi/sain/ImageBitmapEncoding_skikoKt {
+	public static final fun toPngByteArray (Landroidx/compose/ui/graphics/ImageBitmap;)[B
+}
+
 public final class io/github/joelkanyi/sain/SainKt {
 	public static final fun Sain-JOs5j9Q (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFFJLandroidx/compose/foundation/BorderStroke;Landroidx/compose/foundation/shape/CornerBasedShape;Lio/github/joelkanyi/sain/SignatureState;ZJF[FFFLjava/lang/String;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Sain-uKGX-YA (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;JFLio/github/joelkanyi/sain/SignatureState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V

--- a/sain/build.gradle.kts
+++ b/sain/build.gradle.kts
@@ -56,6 +56,16 @@ kotlin {
             implementation(libs.compose.foundation)
         }
 
+        // All non-Android targets render through Skiko, so they share one
+        // implementation of the ImageBitmap encoding helpers.
+        val skikoMain by creating {
+            dependsOn(commonMain.get())
+        }
+        jvmMain.get().dependsOn(skikoMain)
+        iosMain.get().dependsOn(skikoMain)
+        jsMain.get().dependsOn(skikoMain)
+        wasmJsMain.get().dependsOn(skikoMain)
+
         commonTest.dependencies {
             implementation(kotlin("test"))
             @Suppress("DEPRECATION_ERROR")

--- a/sain/src/androidMain/kotlin/io/github/joelkanyi/sain/ImageBitmapEncoding.android.kt
+++ b/sain/src/androidMain/kotlin/io/github/joelkanyi/sain/ImageBitmapEncoding.android.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.joelkanyi.sain
+
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import java.io.ByteArrayOutputStream
+
+public actual fun ImageBitmap.toPngByteArray(): ByteArray {
+    val stream = ByteArrayOutputStream()
+    asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 100, stream)
+    return stream.toByteArray()
+}

--- a/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/ImageBitmapEncoding.kt
+++ b/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/ImageBitmapEncoding.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.joelkanyi.sain
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlin.io.encoding.Base64
+
+/**
+ * Encodes this [ImageBitmap] to a PNG byte array.
+ *
+ * @return The PNG-encoded bytes of this bitmap.
+ */
+public expect fun ImageBitmap.toPngByteArray(): ByteArray
+
+/**
+ * Encodes this [ImageBitmap] to a Base64 string of its PNG representation.
+ *
+ * The returned string contains only the Base64 payload. To use it in an
+ * HTML `img` tag or similar, prepend `data:image/png;base64,` to it.
+ *
+ * @return The Base64-encoded PNG representation of this bitmap.
+ */
+public fun ImageBitmap.toBase64(): String = Base64.encode(toPngByteArray())

--- a/sain/src/jvmTest/kotlin/io/github/joelkanyi/sain/ImageBitmapEncodingTest.kt
+++ b/sain/src/jvmTest/kotlin/io/github/joelkanyi/sain/ImageBitmapEncodingTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.joelkanyi.sain
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ImageBitmapEncodingTest {
+
+    private val pngMagicBytes = byteArrayOf(
+        0x89.toByte(),
+        0x50,
+        0x4E,
+        0x47,
+        0x0D,
+        0x0A,
+        0x1A,
+        0x0A,
+    )
+
+    private fun sampleBitmap() = toImageBitmap(
+        width = 20,
+        height = 10,
+        signatureColor = Color.Black,
+        signatureSize = 2.dp,
+        signatureSignatureLines = listOf(
+            SignatureLine(
+                start = androidx.compose.ui.geometry.Offset(0f, 0f),
+                end = androidx.compose.ui.geometry.Offset(20f, 10f),
+            ),
+        ),
+    )
+
+    @Test
+    fun toPngByteArrayProducesPng() {
+        val bytes = sampleBitmap().toPngByteArray()
+        assertTrue(bytes.size > pngMagicBytes.size)
+        assertContentEquals(pngMagicBytes, bytes.copyOf(pngMagicBytes.size))
+    }
+
+    @Test
+    fun toBase64EncodesPngBytes() {
+        val bitmap = sampleBitmap()
+        val base64 = bitmap.toBase64()
+        assertTrue(base64.isNotEmpty())
+        assertContentEquals(bitmap.toPngByteArray(), Base64.decode(base64))
+    }
+
+    @Test
+    fun encodedImageKeepsDimensions() {
+        val bytes = sampleBitmap().toPngByteArray()
+        val image = org.jetbrains.skia.Image.makeFromEncoded(bytes)
+        assertEquals(20, image.width)
+        assertEquals(10, image.height)
+    }
+}

--- a/sain/src/skikoMain/kotlin/io/github/joelkanyi/sain/ImageBitmapEncoding.skiko.kt
+++ b/sain/src/skikoMain/kotlin/io/github/joelkanyi/sain/ImageBitmapEncoding.skiko.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.joelkanyi.sain
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asSkiaBitmap
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+
+public actual fun ImageBitmap.toPngByteArray(): ByteArray {
+    val image = Image.makeFromBitmap(asSkiaBitmap())
+    val data = image.encodeToData(EncodedImageFormat.PNG)
+        ?: error("Failed to encode ImageBitmap to PNG")
+    return data.bytes
+}


### PR DESCRIPTION
Closes #96.

Adds built-in export helpers for the captured signature, available on all targets (Android, iOS, JVM, JS, WASM):

- `ImageBitmap.toPngByteArray()` encodes the bitmap as PNG bytes
- `ImageBitmap.toBase64()` returns the Base64 string of the PNG bytes (uses the stable kotlin.io.encoding.Base64)

## Implementation
- Android encodes via android.graphics.Bitmap.compress
- All other targets share one Skiko implementation (Image.makeFromBitmap + encodeToData) through a new skikoMain intermediate source set, so there is a single non-Android code path instead of four copies
- JVM tests verify the PNG magic bytes, Base64 round trip, and image dimensions
- API dumps updated

## Docs
- The usage guide previously told users to hand-roll an expect/actual toBase64; that section now documents the built-in API
- Feature lists in README and docs index updated

Stacked on #136 (needs the dependency updates to build). When #136 merges this PR will retarget to main automatically.