### PR TITLE
ci: queue Pages deployments to avoid concurrent deploy failures

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,11 @@ permissions:
   pages: write
   id-token: write
 
+# Pages allows only one deployment at a time; queue instead of racing
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy_docs:
     runs-on: macos-latest


### PR DESCRIPTION
The docs deploy for the #136 merge commit failed because the deployment for the #135 merge was still in progress; GitHub Pages allows only one deployment at a time. Adding a concurrency group with cancel-in-progress disabled queues deployments instead of letting them race.