### PR TITLE
Cut GitHub Actions cost

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: 🧹 Lint
+  verify:
+    name: 🔎 Verify (JVM/Android/JS/Wasm)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -31,87 +31,31 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Spotless check
-        run: ./gradlew spotlessCheck --stacktrace
+      - name: Spotless + API + tests
+        run: ./gradlew spotlessCheck apiCheck :sain:jvmTest --stacktrace
 
-  api-check:
-    name: 🕵️ API Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: API check
-        run: ./gradlew apiCheck --stacktrace
-
-  test:
-    name: 🧪 Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Run tests
-        run: ./gradlew :sain:jvmTest --stacktrace
-
-  build:
-    name: 🔨 Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Build library
+      - name: Build library + samples
         run: >-
           ./gradlew
           :sain:compileAndroidMain
           :sain:jvmJar
           :sain:compileKotlinJs
           :sain:compileKotlinWasmJs
-          --stacktrace
-
-      - name: Build samples
-        run: >-
-          ./gradlew
           :sample:android:assembleDebug
           :sample:desktop:jar
           :sample:web-js:jsBrowserDevelopmentWebpack
           :sample:web-wasm:wasmJsBrowserDevelopmentWebpack
           --stacktrace
 
+  # macOS runs ONLY on push to main, never on PRs (biggest saver). Konan cached,
+  # single simulator target compiled.
   build-ios:
     name: 🍎 Build iOS
+    if: github.event_name != 'pull_request'
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -119,12 +63,15 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
 
+      - name: Cache Konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Build iOS targets
-        run: >-
-          ./gradlew
-          :sain:compileKotlinIosArm64
-          :sain:compileKotlinIosSimulatorArm64
-          --stacktrace
+      - name: Build iOS target
+        run: ./gradlew :sain:compileKotlinIosSimulatorArm64 --stacktrace


### PR DESCRIPTION
Reduce metered macOS minutes on CI.

- Run the iOS build only on push to `main`, not on every PR.
- Cache `~/.konan`; compile a single `iosSimulatorArm64` target.
- Collapse lint/api-check/test/build into one `verify` job.
- Add `timeout-minutes`.