### PR TITLE
Put compileSdk back to 36 (fixes #146)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 kotlin = "2.4.0"
 agp = "9.2.1"
-core-ktx = "1.19.0"
 compose-multipatform = "1.11.1"
 compose-activity = "1.13.0"
 spotless = "8.8.0"
@@ -14,7 +13,6 @@ android-compileSdk = "36"
 android-minSdk = "23"
 
 [libraries]
-androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose-activity" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multipatform" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multipatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ dokka = "2.2.0"
 gradleMavenPublish = "0.37.0"
 nmcp = "1.6.1"
 
-android-compileSdk = "37"
+android-compileSdk = "36"
 android-minSdk = "23"
 
 [libraries]

--- a/sain/build.gradle.kts
+++ b/sain/build.gradle.kts
@@ -51,9 +51,12 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
-            implementation(libs.compose.ui)
-            implementation(libs.compose.foundation)
+            // These are declared api, not implementation, because their types
+            // (Composer, Saver, Modifier, ImageBitmap, BorderStroke,
+            // CornerBasedShape, TextStyle) appear in Sain's public API.
+            api(libs.compose.runtime)
+            api(libs.compose.ui)
+            api(libs.compose.foundation)
         }
 
         // All non-Android targets render through Skiko, so they share one

--- a/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
+++ b/sain/src/commonMain/kotlin/io/github/joelkanyi/sain/Sain.kt
@@ -125,7 +125,7 @@ public fun Sain(
                     border = signatureBorderStroke,
                     shape = signaturePadShape,
                 )
-                .pointerInput(true) {
+                .pointerInput(state) {
                     detectDragGestures { change, dragAmount ->
                         change.consume()
                         val signatureLine = SignatureLine(
@@ -257,7 +257,7 @@ public fun Sain(
     Column {
         Box(
             modifier = modifier
-                .pointerInput(true) {
+                .pointerInput(state) {
                     detectDragGestures { change, dragAmount ->
                         change.consume()
 
@@ -357,17 +357,18 @@ public class SignatureState {
                 }
             },
             restore = { saved ->
-                @Suppress("UNCHECKED_CAST")
-                val points = saved as List<List<Float>>
+                val rows = saved as? List<*> ?: emptyList<Any?>()
                 SignatureState().apply {
-                    _signatureLines.addAll(
-                        points.map {
+                    for (row in rows) {
+                        val coords = (row as? List<*>)?.filterIsInstance<Float>() ?: continue
+                        if (coords.size < 4) continue
+                        _signatureLines.add(
                             SignatureLine(
-                                start = Offset(it[0], it[1]),
-                                end = Offset(it[2], it[3]),
-                            )
-                        },
-                    )
+                                start = Offset(coords[0], coords[1]),
+                                end = Offset(coords[2], coords[3]),
+                            ),
+                        )
+                    }
                 }
             },
         )

--- a/sain/src/commonTest/kotlin/io/github/joelkanyi/sain/SignatureStateTest.kt
+++ b/sain/src/commonTest/kotlin/io/github/joelkanyi/sain/SignatureStateTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.SaverScope
 import androidx.compose.ui.geometry.Offset
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -147,6 +148,20 @@ class SignatureStateTest {
         assertEquals(originalLine.start.y, restoredLine.start.y)
         assertEquals(originalLine.end.x, restoredLine.end.x)
         assertEquals(originalLine.end.y, restoredLine.end.y)
+    }
+
+    @Test
+    fun saverToleratesMalformedInput() {
+        val restored = SignatureState.Saver.restore(listOf("not", "floats"))
+        assertNotNull(restored)
+        assertTrue(restored.signatureLines.isEmpty())
+    }
+
+    @Test
+    fun saverSkipsRowsWithMissingCoordinates() {
+        val restored = SignatureState.Saver.restore(listOf(listOf(1f, 2f)))
+        assertNotNull(restored)
+        assertTrue(restored.signatureLines.isEmpty())
     }
 
     @Test

--- a/sample/android/build.gradle.kts
+++ b/sample/android/build.gradle.kts
@@ -86,7 +86,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core.ktx)
     implementation(libs.compose.activity)
     implementation(project(":sample:shared"))
 }


### PR DESCRIPTION
2.2.0 built against compileSdk 37, which is a preview level. Nothing in the library needs it, and building against it makes the AAR demand compileSdk 37 (and the newest AGP) from everyone who depends on sain. This puts it back to 36.

While I was in here I also cleaned up a few things:

- Moved the Compose deps to `api`. Their types (Modifier, ImageBitmap, BorderStroke, TextStyle) show up in the public API, so they belong on the consumer's compile classpath, not just runtime.
- Keyed the drag gesture on `state` instead of a constant, so it stops writing to an old instance if the state is swapped.
- Made Saver.restore skip malformed rows instead of crashing on a bad bundle. Added tests for it.
- Dropped androidx.core-ktx from the sample. It was unused, and its 1.19.0 was the only thing forcing the sample onto 37.

No public API changes. apiCheck, jvmTest, and the sample build are green at 36. iOS is on CI.

Closes #146
